### PR TITLE
feat: Expose internal Alamofire session as read-only

### DIFF
--- a/Sources/GoodNetworking/Session/NetworkSession.swift
+++ b/Sources/GoodNetworking/Session/NetworkSession.swift
@@ -15,12 +15,12 @@ public class NetworkSession {
 
     public static var `default` = NetworkSession()
 
-    // MARK: - Private
+    // MARK: - Variables
 
-    private let session: Alamofire.Session
-    private let configuration: NetworkSessionConfiguration?
+    let session: Alamofire.Session
+    let configuration: NetworkSessionConfiguration?
 
-    private let baseUrl: String?
+    let baseUrl: String?
 
     // MARK: - Initialization
 


### PR DESCRIPTION
To be able to (at the very least) cancel pending/running Alamofire requests, `Alamofire.Session` API should be available and accessible from outside.