### PR TITLE
Update GoodLogger dependency in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.0")),
         .package(url: "https://github.com/Alamofire/AlamofireImage.git", .upToNextMajor(from: "4.2.0")),
         .package(url: "https://github.com/KittyMac/Sextant.git", .upToNextMinor(from: "0.4.31")),
-        .package(url: "https://github.com/GoodRequest/GoodLogger.git", .upToNextMajor(from: "1.0.0"))
+        .package(url: "https://github.com/GoodRequest/GoodLogger.git", .upToNextMajor(from: "1.2.4"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
GoodLogger minimum required version is 1.2.4, as that is the first version where Logger became Sendable.