### PR TITLE
fix: Bugfixing round

### DIFF
--- a/Sources/GoodNetworking/Extensions/WithCustomCoder.swift
+++ b/Sources/GoodNetworking/Extensions/WithCustomCoder.swift
@@ -9,7 +9,6 @@ import Foundation
 
 // MARK: - Encodable extensions
 
-@available(*, deprecated, message: "Prefer custom encode(to:) implementation instead where required")
 public protocol WithCustomEncoder {
     
     static var encoder: JSONEncoder { get }
@@ -18,7 +17,6 @@ public protocol WithCustomEncoder {
     
 }
 
-@available(*, deprecated, message: "Prefer custom encode(to:) implementation instead where required")
 public extension Encodable where Self: WithCustomEncoder {
     
     /// The `keyEncodingStrategy` property returns the default key encoding strategy of the `JSONEncoder`.
@@ -62,7 +60,6 @@ public extension Encodable where Self: WithCustomEncoder {
 
 // MARK: - Decodable extensions
 
-@available(*, deprecated, message: "Prefer custom init(from decoder:) implementation instead where required")
 public protocol WithCustomDecoder {
     
     static var decoder: JSONDecoder { get }
@@ -71,7 +68,6 @@ public protocol WithCustomDecoder {
     
 }
 
-@available(*, deprecated, message: "Prefer custom init(from decoder:) implementation instead where required")
 public extension Decodable where Self: WithCustomDecoder {
     
     /// Defines the `KeyDecodingStrategy` for all `Decodable WithCustomDecoder` objects using this extension.

--- a/Sources/GoodNetworking/Models/Endpoint.swift
+++ b/Sources/GoodNetworking/Models/Endpoint.swift
@@ -71,7 +71,7 @@ public extension Endpoint {
 public enum EndpointParameters {
 
     /// Case for sending `Parameters`.
-    @available(*, deprecated, renamed: "json", message: "Use JSON instead of raw dictionaries")
+    @available(*, deprecated, renamed: "model", message: "Use model(JSON) instead of raw dictionaries")
     case parameters([String: Any])
 
     case query([URLQueryItem])
@@ -79,8 +79,6 @@ public enum EndpointParameters {
     case model(Encodable)
     
     case data(Data)
-    
-    case json(JSON)
 
     public var dictionary: JSON? {
         switch self {
@@ -103,9 +101,6 @@ public enum EndpointParameters {
             
         case .data(let data):
             return try? JSON(data: data)
-            
-        case .json(let json):
-            return json
         }
     }
 
@@ -130,9 +125,6 @@ public enum EndpointParameters {
             
         case .data(let data):
             return data
-            
-        case .json(let json):
-            return json.data()
         }
     }
 

--- a/Sources/GoodNetworking/Models/Endpoint.swift
+++ b/Sources/GoodNetworking/Models/Endpoint.swift
@@ -116,7 +116,13 @@ public enum EndpointParameters {
                         
         case .model(let codableModel):
             do {
-                let encoder = JSONEncoder()
+                let encoder: JSONEncoder
+                if let customEncodable = codableModel as? WithCustomEncoder {
+                    encoder = type(of: customEncodable).encoder
+                } else {
+                    encoder = JSONEncoder()
+                }
+
                 return try encoder.encode(codableModel)
             } catch {
                 throw URLError(.cannotEncodeRawData).asNetworkError()

--- a/Sources/GoodNetworking/Models/EndpointBuilder.swift
+++ b/Sources/GoodNetworking/Models/EndpointBuilder.swift
@@ -68,10 +68,11 @@ public extension EndpointBuilder {
         self.parameters = .model(model)
         return self
     }
-    
+
+    @available(*, deprecated, renamed: "body(model:)", message: "JSON conforms to Codable; use generic interfaces instead")
     func body(json: JSON) -> Self {
         assertBothQueryAndBodyUsage()
-        self.parameters = .json(json)
+        self.parameters = .model(json)
         return self
     }
     

--- a/Sources/GoodNetworking/Models/JSON.swift
+++ b/Sources/GoodNetworking/Models/JSON.swift
@@ -117,10 +117,14 @@ import Foundation
             self = JSON.array(array.map { JSON($0) })
         } else if let string = object as? String {
             self = JSON.string(string)
-        } else if let number = object as? NSNumber {
-            self = JSON.number(number)
-        } else if let bool = object as? Bool {
+        } else if let bool = object as? Bool, !(object is NSNumber) {
             self = JSON.bool(bool)
+        } else if let number = object as? NSNumber {
+            if number.isBool {
+                self = JSON.bool(number.boolValue)
+            } else {
+                self = JSON.number(number)
+            }
         } else if let json = object as? JSON {
             self = json
         } else {
@@ -350,4 +354,24 @@ extension JSON: Swift.CustomStringConvertible, Swift.CustomDebugStringConvertibl
         return description
     }
     
+}
+
+// MARK: - NSNumber handling
+
+private extension NSNumber {
+
+    var isBool: Bool {
+        CFGetTypeID(self) == CFBooleanGetTypeID()
+    }
+
+    var isFloatingPoint: Bool {
+        let type = String(cString: objCType)
+        return type == "f" || type == "d"
+    }
+
+    var isSignedInteger: Bool {
+        let type = String(cString: objCType)
+        return ["c", "s", "i", "l", "q"].contains(type)
+    }
+
 }

--- a/Sources/GoodNetworking/Models/JSON.swift
+++ b/Sources/GoodNetworking/Models/JSON.swift
@@ -107,7 +107,9 @@ import Foundation
     ///
     /// - Parameter object: Object to try to represent as JSON
     public init(_ object: Any) {
-        if let data = object as? Data, let jsonData = try? JSON(data: data) {
+        if let jsonData = object as? JSON {
+            self = jsonData
+        } else if let data = object as? Data, let jsonData = try? JSON(data: data) {
             self = jsonData
         } else if let model = object as? any Encodable, let data = try? JSONEncoder().encode(model), let jsonData = try? JSON(data: data) {
             self = jsonData
@@ -125,13 +127,11 @@ import Foundation
             } else {
                 self = JSON.number(number)
             }
-        } else if let json = object as? JSON {
-            self = json
         } else {
             self = JSON.null
         }
     }
-    
+
     // MARK: - Accessors
     
     /// Access the JSON value as a dictionary
@@ -354,6 +354,124 @@ extension JSON: Swift.CustomStringConvertible, Swift.CustomDebugStringConvertibl
         return description
     }
     
+}
+
+// MARK: - Decodable
+
+extension JSON: Decodable {
+
+    public init(from decoder: Decoder) throws {
+        // top level is dictionary (most cases)
+        if let container = try? decoder.container(keyedBy: DynamicJSONCodingKey.self) {
+            var dictionary: [String: JSON] = [:]
+
+            for key in container.allKeys {
+                dictionary[key.stringValue] = try container.decode(JSON.self, forKey: key)
+            }
+
+            self = .dictionary(dictionary)
+            return
+        }
+
+        // top level is array
+        if var container = try? decoder.unkeyedContainer() {
+            var array: [JSON] = []
+
+            while !container.isAtEnd {
+                array.append(try container.decode(JSON.self))
+            }
+
+            self = .array(array)
+            return
+        }
+
+        // top level is only single value (uncommon)
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int64.self) {
+            self = .number(NSNumber(value: value))
+        } else if let value = try? container.decode(UInt64.self) {
+            self = .number(NSNumber(value: value))
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(NSNumber(value: value))
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            self = .null
+        }
+    }
+
+}
+
+// MARK: - Encodable
+
+extension JSON: Encodable {
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .dictionary(let dictionary):
+            var container = encoder.container(keyedBy: DynamicJSONCodingKey.self)
+
+            for (key, value) in dictionary {
+                try container.encode(value, forKey: DynamicJSONCodingKey(stringValue: key))
+            }
+
+        case .array(let array):
+            var container = encoder.unkeyedContainer()
+
+            for value in array {
+                try container.encode(value)
+            }
+
+        case .string(let string):
+            var container = encoder.singleValueContainer()
+            try container.encode(string)
+
+        case .number(let number):
+            var container = encoder.singleValueContainer()
+
+            if number.isBool {
+                try container.encode(number.boolValue)
+            } else if number.isFloatingPoint {
+                try container.encode(number.doubleValue)
+            } else if number.isSignedInteger {
+                try container.encode(number.int64Value)
+            } else {
+                try container.encode(number.uint64Value)
+            }
+
+        case .bool(let bool):
+            var container = encoder.singleValueContainer()
+            try container.encode(bool)
+
+        case .null:
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        }
+    }
+
+}
+
+// MARK: - Coding key
+
+private struct DynamicJSONCodingKey: CodingKey {
+
+    let stringValue: String
+    let intValue: Int?
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init(intValue: Int) {
+        self.stringValue = String(intValue)
+        self.intValue = intValue
+    }
+
 }
 
 // MARK: - NSNumber handling

--- a/Sources/GoodNetworking/Session/NetworkSession.swift
+++ b/Sources/GoodNetworking/Session/NetworkSession.swift
@@ -306,14 +306,11 @@ extension NetworkSession {
     }
     
     // MARK: JSON
-    
+
+    @available(*, deprecated, message: "JSON conforms to Codable; use generic interfaces instead")
     @_disfavoredOverload
     public func request(endpoint: Endpoint) async throws(NetworkError) -> JSON {
-        let response: NetworkResponse = try await request(endpoint: endpoint)
-        guard let json = try? JSON(data: response.body) else {
-            throw URLError(.cannotDecodeRawData).asNetworkError()
-        }
-        return json
+        try await request(endpoint: endpoint) as JSON
     }
     
     // MARK: Raw

--- a/Sources/GoodNetworking/Session/NetworkSession.swift
+++ b/Sources/GoodNetworking/Session/NetworkSession.swift
@@ -348,62 +348,8 @@ extension NetworkSession {
             request.setValue(header.value, forHTTPHeaderField: header.name)
         }
         
-        // encoding
-        switch endpoint.parameters {
-        case .parameters(let parameters):
-            if endpoint.encoding is URLEncoding {
-                applyQueryParameters(to: &request, endpoint, url)
-            } else if endpoint.encoding is JSONEncoding {
-                logger.logNetworkEvent(
-                    message: "Attempt to encode dictionary as body, use JSON or Encodable instead",
-                    level: .error,
-                    file: #file,
-                    line: #line
-                )
-                request.httpBody = try endpoint.parameters?.data()
-            } else if endpoint.encoding is AutomaticEncoding {
-                request.httpBody = try endpoint.parameters?.data()
-            }
-            
-        case .query(let queryItems):
-            if endpoint.encoding is URLEncoding {
-                applyQueryParameters(to: &request, endpoint, url)
-            } else if endpoint.encoding is JSONEncoding {
-                preconditionFailure("Attempt to encode query parameters as JSON body")
-            } else if endpoint.encoding is AutomaticEncoding {
-                applyQueryParameters(to: &request, endpoint, url)
-            }
-            
-        case .model(let encodableModel):
-            if endpoint.encoding is URLEncoding {
-                applyQueryParameters(to: &request, endpoint, url)
-            } else if endpoint.encoding is JSONEncoding {
-                request.httpBody = try endpoint.parameters?.data()
-            } else if endpoint.encoding is AutomaticEncoding {
-                request.httpBody = try endpoint.parameters?.data()
-            }
-            
-        case .data(let data):
-            if endpoint.encoding is URLEncoding {
-                preconditionFailure("Encoding raw data into query is not supported")
-            } else if endpoint.encoding is JSONEncoding {
-                request.httpBody = try endpoint.parameters?.data()
-            } else if endpoint.encoding is AutomaticEncoding {
-                request.httpBody = try endpoint.parameters?.data()
-            }
-            
-        case .json(let json):
-            if endpoint.encoding is URLEncoding {
-                applyQueryParameters(to: &request, endpoint, url)
-            } else if endpoint.encoding is JSONEncoding {
-                request.httpBody = try endpoint.parameters?.data()
-            } else if endpoint.encoding is AutomaticEncoding {
-                request.httpBody = try endpoint.parameters?.data()
-            }
-            
-        case .none:
-            request.httpBody = nil
-        }
+        // encoding parameters
+        try applyParameters(to: &request, endpoint, url)
 
         return try await executeRequest(request: &request)
     }
@@ -482,8 +428,49 @@ private extension NetworkSession {
             return try await self.executeRequest(request: &request)
         }
     }
-    
-    @available(*, deprecated, message: "Unify parameter handling")
+
+    private func applyParameters(
+        to request: inout URLRequest,
+        _ endpoint: any Endpoint,
+        _ url: URL,
+    ) throws(NetworkError) {
+        if case .none = endpoint.parameters {
+            request.httpBody = nil
+            return
+        }
+        if endpoint.encoding is URLEncoding {
+            if case .data = endpoint.parameters {
+                let message = "Encoding raw data into query is not supported"
+                logger.logNetworkEvent(message: message, level: .error, file: #file, line: #line)
+                throw NetworkError.local(URLError(.cannotEncodeRawData))
+            }
+            applyQueryParameters(to: &request, endpoint, url)
+        } else if endpoint.encoding is JSONEncoding {
+            if case .query = endpoint.parameters {
+                let message = "Attempt to encode query parameters as JSON body"
+                logger.logNetworkEvent(message: message, level: .error, file: #file, line: #line)
+                throw NetworkError.local(URLError(.cannotEncodeRawData))
+            }
+            if endpoint.method.hasRequestBody {
+                try applyBodyParameters(to: &request, endpoint, url)
+            } else {
+                let message = "Attempted to encode body for request that does not allow a request body"
+                logger.logNetworkEvent(message: message, level: .error, file: #file, line: #line)
+                throw NetworkError.local(URLError(.cannotEncodeRawData))
+            }
+        } else { // AutomaticEncoding or not specified
+            if endpoint.method.hasRequestBody { // Apply request body if available
+                try applyBodyParameters(to: &request, endpoint, url)
+            } else { // else apply as query
+                applyQueryParameters(to: &request, endpoint, url)
+            }
+        }
+    }
+
+    private func applyBodyParameters(to request: inout URLRequest, _ endpoint: any Endpoint, _ url: URL) throws(NetworkError) {
+        request.httpBody = try endpoint.parameters?.data()
+    }
+
     private func applyQueryParameters(to request: inout URLRequest, _ endpoint: any Endpoint, _ url: URL) {
         if #available(iOS 16, macOS 13, *) {
             request.url?.append(queryItems: endpoint.parameters?.queryItems() ?? [])

--- a/Sources/GoodNetworking/Session/NetworkSession.swift
+++ b/Sources/GoodNetworking/Session/NetworkSession.swift
@@ -279,8 +279,8 @@ extension NetworkSession {
         case is Data.Type, is Optional<Data>.Type:
             return data as! T
             
-        case let t as WithCustomDecoder:
-            decoder = type(of: t).decoder
+        case let t as WithCustomDecoder.Type:
+            decoder = t.decoder
             
         default:
             break

--- a/Sources/GoodNetworking/Session/NetworkSession.swift
+++ b/Sources/GoodNetworking/Session/NetworkSession.swift
@@ -196,6 +196,8 @@ extension NetworkSessionDelegate: URLSessionDelegate {
                     file: #file,
                     line: #line
                 )
+
+                completionHandler(.cancelAuthenticationChallenge, nil)
             }
         }
     }

--- a/Sources/GoodNetworking/Session/Shortened.swift
+++ b/Sources/GoodNetworking/Session/Shortened.swift
@@ -14,11 +14,7 @@ extension NetworkSession {
     public func get<T: Decodable>(_ path: URLConvertible) async throws(NetworkError) -> T {
         return try await request(endpoint: at(path).method(.get))
     }
-    
-    public func get(_ path: URLConvertible) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.get))
-    }
-    
+
     public func get(_ path: URLConvertible) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.get))
     }
@@ -35,28 +31,7 @@ extension NetworkSession {
         return try await request(endpoint: at(path).method(.post).body(model: model))
     }
     
-    public func post<R: Decodable>(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> R {
-        return try await request(endpoint: at(path).method(.post).body(json: body))
-    }
-    
     public func post<R: Decodable>(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> R {
-        return try await request(endpoint: at(path).method(.post).body(data: data))
-    }
-    
-    // JSON
-    
-    @discardableResult
-    public func post<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.post).body(model: model))
-    }
-    
-    @discardableResult
-    public func post(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.post).body(json: body))
-    }
-    
-    @discardableResult
-    public func post(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> JSON {
         return try await request(endpoint: at(path).method(.post).body(data: data))
     }
     
@@ -64,10 +39,6 @@ extension NetworkSession {
     
     public func post<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.post).body(model: model))
-    }
-    
-    public func post(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> Data {
-        return try await request(endpoint: at(path).method(.post).body(json: body))
     }
     
     public func post(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {
@@ -85,29 +56,8 @@ extension NetworkSession {
     public func put<T: Encodable, R: Decodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> R {
         return try await request(endpoint: at(path).method(.put).body(model: model))
     }
-    
-    public func put<R: Decodable>(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> R {
-        return try await request(endpoint: at(path).method(.put).body(json: body))
-    }
-    
+
     public func put<R: Decodable>(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> R {
-        return try await request(endpoint: at(path).method(.put).body(data: data))
-    }
-    
-    // JSON
-    
-    @discardableResult
-    public func put<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.put).body(model: model))
-    }
-    
-    @discardableResult
-    public func put(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.put).body(json: body))
-    }
-    
-    @discardableResult
-    public func put(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> JSON {
         return try await request(endpoint: at(path).method(.put).body(data: data))
     }
     
@@ -115,10 +65,6 @@ extension NetworkSession {
     
     public func put<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.put).body(model: model))
-    }
-    
-    public func put(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> Data {
-        return try await request(endpoint: at(path).method(.put).body(json: body))
     }
     
     public func put(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {
@@ -137,39 +83,14 @@ extension NetworkSession {
         return try await request(endpoint: at(path).method(.patch).body(model: model))
     }
     
-    public func patch<R: Decodable>(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> R {
-        return try await request(endpoint: at(path).method(.patch).body(json: body))
-    }
-    
     public func patch<R: Decodable>(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> R {
         return try await request(endpoint: at(path).method(.patch).body(data: data))
     }
-    
-    // JSON
-    
-    @discardableResult
-    public func patch<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.patch).body(model: model))
-    }
-    
-    @discardableResult
-    public func patch(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.patch).body(json: body))
-    }
-    
-    @discardableResult
-    public func patch(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.patch).body(data: data))
-    }
-    
+
     // Raw
     
     public func patch<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.patch).body(model: model))
-    }
-    
-    public func patch(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> Data {
-        return try await request(endpoint: at(path).method(.patch).body(json: body))
     }
     
     public func patch(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {
@@ -188,28 +109,7 @@ extension NetworkSession {
         return try await request(endpoint: at(path).method(.delete).body(model: model))
     }
     
-    public func delete<R: Decodable>(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> R {
-        return try await request(endpoint: at(path).method(.delete).body(json: body))
-    }
-    
     public func delete<R: Decodable>(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> R {
-        return try await request(endpoint: at(path).method(.delete).body(data: data))
-    }
-    
-    // JSON
-    
-    @discardableResult
-    public func delete<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.delete).body(model: model))
-    }
-    
-    @discardableResult
-    public func delete(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> JSON {
-        return try await request(endpoint: at(path).method(.delete).body(json: body))
-    }
-    
-    @discardableResult
-    public func delete(_ path: URLConvertible, data: Data? = nil) async throws(NetworkError) -> JSON {
         return try await request(endpoint: at(path).method(.delete).body(data: data))
     }
     
@@ -217,10 +117,6 @@ extension NetworkSession {
     
     public func delete<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.delete).body(model: model))
-    }
-    
-    public func delete(_ path: URLConvertible, _ body: JSON) async throws(NetworkError) -> Data {
-        return try await request(endpoint: at(path).method(.delete).body(json: body))
     }
     
     public func delete(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {

--- a/Sources/GoodNetworking/Session/Shortened.swift
+++ b/Sources/GoodNetworking/Session/Shortened.swift
@@ -36,11 +36,13 @@ extension NetworkSession {
     }
     
     // Raw
-    
+
+    @discardableResult
     public func post<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.post).body(model: model))
     }
-    
+
+    @discardableResult
     public func post(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.post).body(data: data))
     }
@@ -62,11 +64,13 @@ extension NetworkSession {
     }
     
     // Raw
-    
+
+    @discardableResult
     public func put<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.put).body(model: model))
     }
-    
+
+    @discardableResult
     public func put(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.put).body(data: data))
     }
@@ -88,11 +92,13 @@ extension NetworkSession {
     }
 
     // Raw
-    
+
+    @discardableResult
     public func patch<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.patch).body(model: model))
     }
-    
+
+    @discardableResult
     public func patch(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.patch).body(data: data))
     }
@@ -114,11 +120,13 @@ extension NetworkSession {
     }
     
     // Raw
-    
+
+    @discardableResult
     public func delete<T: Encodable>(_ path: URLConvertible, _ model: T) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.delete).body(model: model))
     }
-    
+
+    @discardableResult
     public func delete(_ path: URLConvertible, data: Data?) async throws(NetworkError) -> Data {
         return try await request(endpoint: at(path).method(.delete).body(data: data))
     }

--- a/Tests/GoodNetworkingTests/BugfixRoundTests.swift
+++ b/Tests/GoodNetworkingTests/BugfixRoundTests.swift
@@ -1,0 +1,103 @@
+//
+//  BugfixRoundTests.swift
+//  GoodNetworking
+//
+//  Tests covering fixes from PR #59 (bugfixing round).
+//
+
+@testable import GoodNetworking
+import Testing
+import Foundation
+
+// MARK: - JSON NSNumber boolean handling
+
+@Test func jsonDistinguishesBoolsFromNumbers() throws {
+    #expect(JSON(true) == JSON.bool(true))
+    #expect(JSON(NSNumber(value: true)) == JSON.bool(true))
+    #expect(JSON(NSNumber(value: 1)) == JSON.number(1))
+    #expect(JSON(1) == JSON.number(1))
+    #expect(JSON(1.5) == JSON.number(1.5))
+}
+
+// MARK: - JSON Codable conformance
+
+@Test func jsonCodableRoundTrip() throws {
+    let original: JSON = [
+        "name": "Alice",
+        "age": 30,
+        "isAdmin": true,
+        "score": 12.5,
+        "tags": ["a", "b"],
+        "nested": ["key": "value"]
+    ]
+
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(JSON.self, from: encoded)
+
+    #expect(decoded.name.string == "Alice")
+    #expect(decoded.age.int == 30)
+    #expect(decoded.isAdmin.bool == true)
+    #expect(decoded.score.double == 12.5)
+    #expect(decoded.tags.array?.count == 2)
+    #expect(decoded.nested.key.string == "value")
+}
+
+// MARK: - WithCustomEncoder support in EndpointParameters
+
+private struct SnakeCaseModel: Encodable, WithCustomEncoder {
+
+    static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        return encoder
+    }
+
+    let firstName: String
+
+}
+
+@Test func endpointParametersUseCustomEncoder() throws {
+    let parameters = EndpointParameters.model(SnakeCaseModel(firstName: "Alice"))
+    let data = try #require(try parameters.data())
+    let jsonString = try #require(String(data: data, encoding: .utf8))
+
+    #expect(jsonString.contains("first_name"))
+}
+
+// MARK: - Data/Encodable metatype casting (WithCustomDecoder)
+
+private struct SnakeCaseResponse: Decodable, WithCustomDecoder {
+
+    static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+
+    let firstName: String
+
+}
+
+@Test func customDecoderMetatypeCastResolves() throws {
+    // Before the fix, `case let t as WithCustomDecoder` never matched a metatype,
+    // silently falling back to the default decoder.
+    let match = SnakeCaseResponse.self as? WithCustomDecoder.Type
+    let decoder = try #require(match).decoder
+
+    let data = Data(#"{"first_name": "Alice"}"#.utf8)
+    let decoded = try decoder.decode(SnakeCaseResponse.self, from: data)
+    #expect(decoded.firstName == "Alice")
+}
+
+// MARK: - Query parameter encoding (live)
+
+@Test func queryParametersEncodeCorrectly() async throws {
+    let response: JSON = try await session.request(
+        endpoint: at("/products/search")
+            .method(.get)
+            .query([URLQueryItem(name: "q", value: "apple watch")])
+    )
+
+    let total = try #require(response.total.int)
+    #expect(total > 0)
+}

--- a/Tests/GoodNetworkingTests/NetworkSessionTests.swift
+++ b/Tests/GoodNetworkingTests/NetworkSessionTests.swift
@@ -8,8 +8,6 @@
 @testable import GoodNetworking
 import Testing
 import Foundation
-import Sextant
-import Hitch
 
 let session = NetworkSession(baseUrl: "https://dummyjson.com")
 
@@ -126,8 +124,8 @@ struct ProductsResponse: Decodable {
         "age": 30
     ] as JSON
     
-    _ = try await session.post("/users", newUser) as JSON
-    _ = try await session.post("/users", newUserJson) as JSON
+    _ = try await session.post("/users/add", newUser) as JSON
+    _ = try await session.post("/users/add", newUserJson) as JSON
 }
 
 struct NewUserRequest: Encodable {


### PR DESCRIPTION
Re-opened version of #59 (could not be reopened after new commits landed on the branch).

Fixed multiple small bugs found over time, including:
- Invalid encoding of query parameters
- Data/Encodable invalid casting
- JSON enum NSNumber handling
- Certificate pinning missing completionHandler call

Added:
- JSON enum now conforms to Codable for easier manipulation
- WithCustomEncoder/WithCustomDecoder in models is officially supported again
- `@discardableResult` in both long/short network request calls

Additionally (new commit on top of #59):
- Fixed test target compilation (stale Sextant/Hitch imports left over after #52)
- Fixed `encodeDynamicJSON` test to use the correct dummyjson endpoint (`/users/add`)
- Added targeted tests covering the fixes above — full suite passes (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)